### PR TITLE
metrics: implement metrics reset

### DIFF
--- a/pkg/metrics/fakes.go
+++ b/pkg/metrics/fakes.go
@@ -98,6 +98,16 @@ func (b *node) findCounter(labelsMap map[string]string) *node {
 	return b.root.children[canonicalLabels]
 }
 
+func (b *node) reset() {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+
+	for k := range b.children {
+		delete(b.children, k)
+	}
+	b.v = 0
+}
+
 func (b *node) add(delta float64, canBeNegative bool) {
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
@@ -170,6 +180,11 @@ func (c *TestCounter) With(labels ...string) Counter {
 	}
 }
 
+// Reset deletes all metrics in this counter.
+func (c *TestCounter) Reset() {
+	c.reset()
+}
+
 // CounterValue extracts the value out of a TestCounter. If the argument is not a *TestCounter,
 // CounterValue will panic.
 func CounterValue(c Counter) float64 {
@@ -208,6 +223,11 @@ func (g *TestGauge) With(labels ...string) Gauge {
 	return &TestGauge{
 		node: g.with(labels...),
 	}
+}
+
+// Reset deletes all metrics in this gauge.
+func (g *TestGauge) Reset() {
+	g.reset()
 }
 
 // GaugeValue extracts the value out of a TestGauge. If the argument is not a *TestGauge,

--- a/pkg/metrics/fakes_test.go
+++ b/pkg/metrics/fakes_test.go
@@ -88,6 +88,57 @@ func TestTestCounterWith(t *testing.T) {
 	})
 }
 
+func TestTestCounterReset(t *testing.T) {
+	t.Run("reset without children resets only value", func(t *testing.T) {
+		c := metrics.NewTestCounter()
+
+		c.Add(2)
+		assert.Equal(t, float64(2), metrics.CounterValue(c))
+
+		c.Reset()
+		assert.Equal(t, float64(0), metrics.CounterValue(c))
+	})
+
+	t.Run("reset with children deletes all children", func(t *testing.T) {
+		c := metrics.NewTestCounter()
+
+		child1 := c.With("x", "1")
+		child1.Add(2)
+		assert.Equal(t, float64(2), metrics.CounterValue(child1))
+
+		child2 := c.With("x", "2")
+		child2.Add(3)
+		assert.Equal(t, float64(3), metrics.CounterValue(child2))
+
+		c.Reset()
+		assert.Equal(t, float64(0), metrics.CounterValue(c.With("x", "1")))
+		assert.Equal(t, float64(0), metrics.CounterValue(c.With("x", "2")))
+		assert.Equal(t, float64(0), metrics.CounterValue(c))
+	})
+
+	t.Run("reset with intermediate node", func(t *testing.T) {
+		c := metrics.NewTestCounter()
+
+		intermediate := c.With("x", "1")
+		intermediate.Add(1)
+		child1 := intermediate.With("y", "1")
+		child1.Add(2)
+		child2 := intermediate.With("y", "2")
+		child2.Add(3)
+		assert.Equal(t, float64(2), metrics.CounterValue(c.With("x", "1", "y", "1")))
+		assert.Equal(t, float64(3), metrics.CounterValue(c.With("x", "1", "y", "2")))
+
+		intermediate.Reset()
+		assert.Equal(t, float64(2), metrics.CounterValue(c.With("x", "1", "y", "1")))
+		assert.Equal(t, float64(3), metrics.CounterValue(c.With("x", "1", "y", "2")))
+		assert.Equal(t, float64(0), metrics.CounterValue(c.With("x", "1")))
+
+		c.Reset()
+		assert.Equal(t, float64(0), metrics.CounterValue(c.With("x", "1", "y", "1")))
+		assert.Equal(t, float64(0), metrics.CounterValue(c.With("x", "1", "y", "2")))
+	})
+}
+
 func ExampleTestCounter_simple() {
 	// This example shows how to write a simple test using a TestCounter.
 	type Server struct {
@@ -217,6 +268,57 @@ func TestTestGaugeWith(t *testing.T) {
 
 		assert.Equal(t, float64(3), metrics.GaugeValue(a))
 		assert.Equal(t, float64(3), metrics.GaugeValue(b))
+	})
+}
+
+func TestTestGaugeReset(t *testing.T) {
+	t.Run("reset without children resets only value", func(t *testing.T) {
+		c := metrics.NewTestGauge()
+
+		c.Add(2)
+		assert.Equal(t, float64(2), metrics.GaugeValue(c))
+
+		c.Reset()
+		assert.Equal(t, float64(0), metrics.GaugeValue(c))
+	})
+
+	t.Run("reset with children deletes all children", func(t *testing.T) {
+		c := metrics.NewTestGauge()
+
+		child1 := c.With("x", "1")
+		child1.Add(2)
+		assert.Equal(t, float64(2), metrics.GaugeValue(child1))
+
+		child2 := c.With("x", "2")
+		child2.Add(3)
+		assert.Equal(t, float64(3), metrics.GaugeValue(child2))
+
+		c.Reset()
+		assert.Equal(t, float64(0), metrics.GaugeValue(c.With("x", "1")))
+		assert.Equal(t, float64(0), metrics.GaugeValue(c.With("x", "2")))
+		assert.Equal(t, float64(0), metrics.GaugeValue(c))
+	})
+
+	t.Run("reset with intermediate node", func(t *testing.T) {
+		c := metrics.NewTestGauge()
+
+		intermediate := c.With("x", "1")
+		intermediate.Add(1)
+		child1 := intermediate.With("y", "1")
+		child1.Add(2)
+		child2 := intermediate.With("y", "2")
+		child2.Add(3)
+		assert.Equal(t, float64(2), metrics.GaugeValue(c.With("x", "1", "y", "1")))
+		assert.Equal(t, float64(3), metrics.GaugeValue(c.With("x", "1", "y", "2")))
+
+		intermediate.Reset()
+		assert.Equal(t, float64(2), metrics.GaugeValue(c.With("x", "1", "y", "1")))
+		assert.Equal(t, float64(3), metrics.GaugeValue(c.With("x", "1", "y", "2")))
+		assert.Equal(t, float64(0), metrics.GaugeValue(c.With("x", "1")))
+
+		c.Reset()
+		assert.Equal(t, float64(0), metrics.GaugeValue(c.With("x", "1", "y", "1")))
+		assert.Equal(t, float64(0), metrics.GaugeValue(c.With("x", "1", "y", "2")))
 	})
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -55,6 +55,7 @@ import (
 type Counter interface {
 	With(labelValues ...string) Counter
 	Add(delta float64)
+	Reset()
 }
 
 // Gauge describes a metric that takes specific values over time.
@@ -63,6 +64,7 @@ type Gauge interface {
 	With(labelValues ...string) Gauge
 	Set(value float64)
 	Add(delta float64)
+	Reset()
 }
 
 // Histogram describes a metric that takes repeated observations of the same
@@ -72,6 +74,7 @@ type Gauge interface {
 type Histogram interface {
 	With(labelValues ...string) Histogram
 	Observe(value float64)
+	Reset()
 }
 
 // CounterAdd increases the passed in counter by the amount specified.

--- a/pkg/metrics/mock_metrics/mock.go
+++ b/pkg/metrics/mock_metrics/mock.go
@@ -46,6 +46,18 @@ func (mr *MockCounterMockRecorder) Add(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockCounter)(nil).Add), arg0)
 }
 
+// Reset mocks base method.
+func (m *MockCounter) Reset() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Reset")
+}
+
+// Reset indicates an expected call of Reset.
+func (mr *MockCounterMockRecorder) Reset() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockCounter)(nil).Reset))
+}
+
 // With mocks base method.
 func (m *MockCounter) With(arg0 ...string) metrics.Counter {
 	m.ctrl.T.Helper()

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -118,6 +118,11 @@ func (g *gauge) Add(delta float64) {
 	g.gv.With(makeLabels(g.lvs...)).Add(delta)
 }
 
+// Reset deletes all metrics in this vector.
+func (g *gauge) Reset() {
+	g.gv.Reset()
+}
+
 // newGauge wraps the GaugeVec and returns a usable Gauge object.
 func newGauge(gv *prometheus.GaugeVec) *gauge {
 	return &gauge{
@@ -159,6 +164,11 @@ func (c *counter) Add(delta float64) {
 	c.cv.With(makeLabels(c.lvs...)).Add(delta)
 }
 
+// Reset deletes all metrics in this vector.
+func (c *counter) Reset() {
+	c.cv.Reset()
+}
+
 // histogram implements Histogram via a Prometheus HistogramVec. The difference
 // between a Histogram and a Summary is that Histograms require predefined
 // quantile buckets, and can be statistically aggregated.
@@ -193,6 +203,11 @@ func (h *histogram) With(labelValues ...string) Histogram {
 // Observe implements Histogram.
 func (h *histogram) Observe(value float64) {
 	h.hv.With(makeLabels(h.lvs...)).Observe(value)
+}
+
+// Reset deletes all metrics in this vector.
+func (h *histogram) Reset() {
+	h.hv.Reset()
 }
 
 func makeLabels(labelValues ...string) prometheus.Labels {


### PR DESCRIPTION
This PR adds `Reset()` to the metrics package and implements it for prometheus metrics. This is useful for metrics that only exist for a certain period of time, e.g., a remote gateway peer.